### PR TITLE
Update python version requirement

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
 
     steps:
     - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
         pip install nox
     - name: Test
       run: |
-        nox -s test-api-3.10
+        nox -s test-api-3.11
       env:
         NAI_USERNAME: ${{ secrets.NAI_USERNAME }}
         NAI_PASSWORD: ${{ secrets.NAI_PASSWORD }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,6 +45,10 @@ def install_package(session: nox.Session, *packages: str, dev: bool = False):
     package_file = get_wheel_path(session)
     session.install("-r", "requirements.txt", package_file, *(str(p) for p in packages))
 
+    username = session.env.get('NAI_USERNAME', '<UNKNOWN>')
+    version = session.python or session.run("python", "--version", silent = True)
+    print(f"Using {username} with {version}")
+
 
 @nox.session(name="pre-commit")
 def pre_commit(session: nox.Session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,7 +55,7 @@ def pre_commit(session: nox.Session):
     session.run("pre-commit", "run", "--all-files")
 
 
-test_py_versions = ["3.7", "3.8", "3.9", "3.10"]
+test_py_versions = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 
 @nox.session(py=test_py_versions, name="test-mock")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 packages = [{include = "novelai_api"}]
 
 [tool.poetry.dependencies]
-python = ">=3.7.2,<3.11"
+python = ">=3.7.2,<4.0"
 aiohttp = {extras = ["speedups"], version = "^3.8.3"}
 argon2-cffi = "^21.3.0"
 PyNaCl = "^1.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "novelai-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Python API for the NovelAI REST API"
 license = "MIT"
 authors = ["Aedial <aedial.dev@gmail.com>"]
@@ -15,7 +15,7 @@ classifiers = [
 packages = [{include = "novelai_api"}]
 
 [tool.poetry.dependencies]
-python = ">=3.7.2,<4.0"
+python = ">=3.7.2,<3.12"
 aiohttp = {extras = ["speedups"], version = "^3.8.3"}
 argon2-cffi = "^21.3.0"
 PyNaCl = "^1.5.0"


### PR DESCRIPTION
In theory, all 3.x version should be compatible with the older 3.x versions. Unless a long standing deprecated feature was used, all 3.x versions greater than 3.7.2 will work.

This closes #10