### PR TITLE
Update allowed python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = [{include = "novelai_api"}]
 "Bug Tracker" = "https://github.com/Aedial/novelai-api/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.7.2,<3.12"
+python = "^3.7.2"
 aiohttp = {extras = ["speedups"], version = "^3.8.3"}
 argon2-cffi = "^21.3.0"
 PyNaCl = "^1.5.0"


### PR DESCRIPTION
This pull request expands the support to all versions below 4.0, including the existing support for 3.10. It allows for a wider dependency range of >=3.7.2,<4.0, effectively resolving the problem faced with strict dependency managers such as poetry. Previously, if the allowed Python version range exceeded the one specified in the library, it would not be permitted. However, with this change, poetry will be able to add the dependency even if you're using 3.12 or a higher version (which should be a non-issue).