### PR TITLE
flatten repetition_penalty_whitelist

### DIFF
--- a/novelai_api/_high_level.py
+++ b/novelai_api/_high_level.py
@@ -298,10 +298,12 @@ class HighLevel:
         global_settings.rep_pen_whitelist = repetition_penalty_default_whitelist
 
         params = {
-            "repetition_penalty_whitelist": [
-                *global_params.pop("repetition_penalty_whitelist", []),
-                *preset_params.pop("repetition_penalty_whitelist", []),
-            ]
+            "repetition_penalty_whitelist": list(set(
+                item for sublist in [
+                    global_params.pop("repetition_penalty_whitelist", []),
+                    preset_params.pop("repetition_penalty_whitelist", []),
+                ] for inner_list in sublist for item in inner_list
+            ))
         }
 
         params.update(preset_params)


### PR DESCRIPTION
I noticed the `repetition_penalty_whitelist` is sent to the API as array of arrays while the web ui is sending a flat array of numbers.
Therefore I don't know, if the way we are sending it now is even used by the API.

I'm not sure if my approach is good (I'm not a python developer), but it works.

Feel free to give hints on how better send the list as flat int array.