### PR TITLE
Bugfix/key valuerror after copy

### DIFF
--- a/novelai_api/ImagePreset.py
+++ b/novelai_api/ImagePreset.py
@@ -199,6 +199,7 @@ class ImagePreset:
     }
 
     _TYPE_MAPPING = {
+        "legacy": bool,
         "quality_toggle": bool,
         "resolution": (ImageResolution, tuple),
         "uc_preset": (UCPreset, NoneType),
@@ -208,6 +209,7 @@ class ImagePreset:
         "noise": (int, float),
         "strength": (int, float),
         "scale": (int, float),
+        "uncond_scale": (int, float),
         "steps": int,
         "uc": str,
         "smea": bool,
@@ -219,6 +221,8 @@ class ImagePreset:
         "decrisper": bool,
         "add_original_image": bool,
         "mask": str,
+        "cfg_rescale": float,
+        "noise_schedule": str,
     }
 
     # type completion for __setitem__ and __getitem__

--- a/novelai_api/_high_level.py
+++ b/novelai_api/_high_level.py
@@ -298,12 +298,17 @@ class HighLevel:
         global_settings.rep_pen_whitelist = repetition_penalty_default_whitelist
 
         params = {
-            "repetition_penalty_whitelist": list(set(
-                item for sublist in [
-                    global_params.pop("repetition_penalty_whitelist", []),
-                    preset_params.pop("repetition_penalty_whitelist", []),
-                ] for inner_list in sublist for item in inner_list
-            ))
+            "repetition_penalty_whitelist": list(
+                set(
+                    item
+                    for sublist in [
+                        global_params.pop("repetition_penalty_whitelist", []),
+                        preset_params.pop("repetition_penalty_whitelist", []),
+                    ]
+                    for inner_list in sublist
+                    for item in inner_list
+                )
+            )
         }
 
         params.update(preset_params)

--- a/tests/api/test_imagegen_samplers.py
+++ b/tests/api/test_imagegen_samplers.py
@@ -41,6 +41,7 @@ async def test_samplers(
     logger.info(f"Testing model {model} with sampler {sampler}")
 
     preset = ImagePreset(sampler=sampler)
+    preset.copy()
 
     # Furry doesn't have UCPreset.Preset_Low_Quality_Bad_Anatomy
     if model is ImageModel.Furry:


### PR DESCRIPTION
# Bug Explanation

Trying to `copy` an `ImagePreset` is currently failing. `_DEFAULT` has settings for `legacy`, `uncond_scale`, `cfg_rescale`, and `noise_schedule`.  `_TYPE_MAPPING` does not have those entries.

This causes us to hand in settings (pulled from default) during copy that trigger during __setitem__
```
    def __setitem__(self, key: str, value: Any):
        if key not in self._TYPE_MAPPING:  # _DEFAULT's that have no _TYPE_MAPPING make this explode during .copy()!
            raise ValueError(f"'{key}' is not a valid setting")
```

# Solution

- Updating _TYPE_MAPPING with entries for the _DEFAULT's that it was missing.
- Adding a `preset.copy()` line during tests to prevent setting _DEFAULT's without a corresponding a _TYPE_MAPPING
- Also apparently the pre-commit thought _high_level.py needed some reformatting....